### PR TITLE
added option to install binary with short-name “kval”

### DIFF
--- a/Formula/kubeval.rb
+++ b/Formula/kubeval.rb
@@ -7,8 +7,10 @@ class Kubeval < Formula
 
   bottle :unneeded
 
+  option "with-short-name", "link as kval instead"
+
   def install
-    bin.install "kubeval"
+    bin.install "kubeval" => build.with?("short-name") ? "kval" : "kubeval"
   end
 
   test do


### PR DESCRIPTION
Similar to how https://github.com/ahmetb/kubectx can be installed as `kctx`/`knx` instead of `kubectx`/`kubens` to avoid prefixing conflicts, I added an option to install `kubeval` as `kval`