### PR TITLE
Remove deprecated `bottle :unneeded` from formula

### DIFF
--- a/Formula/kubeval.rb
+++ b/Formula/kubeval.rb
@@ -5,8 +5,6 @@ class Kubeval < Formula
   sha256 "d7a31879e5622ece560167c3f923dcf784636215a42eae98624d37d53bd661fd".downcase
   version "0.8.1"
 
-  bottle :unneeded
-
   def install
     bin.install "kubeval"
   end


### PR DESCRIPTION
Recent versions of Homebrew show this warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the garethr/kubeval tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/garethr/homebrew-kubeval/Formula/kubeval.rb:8
```